### PR TITLE
testcases: unified verdict as "success" or "fail"

### DIFF
--- a/testcases/sema/array-package/array-10.mx
+++ b/testcases/sema/array-package/array-10.mx
@@ -3,7 +3,7 @@ Test Package: Sema_Local_Preview
 Test Target: Array
 Author: 17' Yifan Xu
 Time: 2020-02-26
-Verdict: Failed
+Verdict: Fail
 Comment: The size of array cannot be of boolean type.
 Origin Package: Semantic Pretest
 */

--- a/testcases/sema/array-package/array-11.mx
+++ b/testcases/sema/array-package/array-11.mx
@@ -3,7 +3,7 @@ Test Package: Sema_Local_Preview
 Test Target: Array
 Author: 17' Yifan Xu
 Time: 2020-02-26
-Verdict: Failed
+Verdict: Fail
 Comment: The shape of multidimensional array must be specified from left to right.
 Origin Package: Semantic Pretest
 */

--- a/testcases/sema/bool-compare.mx
+++ b/testcases/sema/bool-compare.mx
@@ -3,6 +3,7 @@ Test Package: Sema_Local_Preview
 Test Target: Bool compares
 Author: Pikachu
 Time: 2019-10-14
+Verdict: Fail
 */
 
 void f(int x, int y, int z){

--- a/testcases/sema/class-package/class-16.mx
+++ b/testcases/sema/class-package/class-16.mx
@@ -3,7 +3,7 @@ Test Package: Sema_Local_Preview
 Test Target: Classes
 Author: 17' Yifan Xu
 Time: 2020-02-26
-Verdict: Failed
+Verdict: Fail
 Comment: The name of class constructor must be the same as the class name.
 Origin Package: Semantic Pretest
 */

--- a/testcases/sema/condition.mx
+++ b/testcases/sema/condition.mx
@@ -3,6 +3,7 @@ Test Package: Sema_Local_Preview
 Test Target: Conditions and scopes
 Author: Pikachu
 Time: 2019-10-13
+Verdict: Fail
 */
 class S{
     int a;

--- a/testcases/sema/ternary-package/ternary-expression-1.mx
+++ b/testcases/sema/ternary-package/ternary-expression-1.mx
@@ -3,7 +3,7 @@ Test Package: Sema_Local_Preview
 Test Target: Ternary Expression
 Author: 21' LIU Yiyu
 Time: 2023-08-02
-Verdict: True
+Verdict: Success
 Origin Package: Semantic Extended
 */
 int main() {


### PR DESCRIPTION
Make all the sema testcases has a line "^Verdict: (Success|Fail)$" to facilitate script writing.