### PR TITLE
testcase: fix verdicts in updated cases.

### DIFF
--- a/testcases/sema/class-package/class-4.mx
+++ b/testcases/sema/class-package/class-4.mx
@@ -3,8 +3,7 @@ Test Package: Sema_Local_Preview
 Test Target: Classes
 Author: 15' Yueyang Xianzang
 Time: 2019-10-20
-Verdict: Fail
-Comment: Class definition should end with semicolon
+Verdict: Success
 Origin Package: Semantic Extended
 */
 class A
@@ -16,7 +15,7 @@ class A
         return this;
     }
     int a;
-}
+};
 int main()
 {
     A A;

--- a/testcases/sema/class-package/class-4.mx
+++ b/testcases/sema/class-package/class-4.mx
@@ -3,7 +3,8 @@ Test Package: Sema_Local_Preview
 Test Target: Classes
 Author: 15' Yueyang Xianzang
 Time: 2019-10-20
-Verdict: Success
+Verdict: Fail
+Comment: Class definition should end with semicolon
 Origin Package: Semantic Extended
 */
 class A

--- a/testcases/sema/ternary-package/ternary-expression-4.mx
+++ b/testcases/sema/ternary-package/ternary-expression-4.mx
@@ -33,5 +33,4 @@ int main() {
     printInt(a);
     printInt(b);
     printInt(c);
-    printInt(d);
 }


### PR DESCRIPTION
1. Semicolon missed in class-4.mx, whose verdict is correct instead.
2. Strange error in ternary-expression-4.mx.